### PR TITLE
Fix bench tests for new criterion

### DIFF
--- a/benchmarks/benches/core_benchmarks.rs
+++ b/benchmarks/benches/core_benchmarks.rs
@@ -1,12 +1,9 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use rush::greet;
+use std::hint::black_box;
 
 fn benchmark_function(c: &mut Criterion) {
-    c.bench_function("greet", |b| {
-        b.iter(|| {
-            black_box(greet())
-        })
-    });
+    c.bench_function("greet", |b| b.iter(|| black_box(greet())));
 }
 
 criterion_group!(benches, benchmark_function);


### PR DESCRIPTION
## Summary
- address failing CI on Ubuntu by removing deprecated `criterion::black_box`
- use `std::hint::black_box` instead and simplify benchmark closure

## Testing
- `cargo test --all-features --workspace --quiet`
- `cargo clippy --all-targets --all-features -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_6881b124e48c832ca6e8e5ade11f49ae