### PR TITLE
Fix CI audit action version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: rustsec/audit-check@v1.2.0
+    - uses: rustsec/audit-check@v2.0.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/benchmarks/benches/core_benchmarks.rs
+++ b/benchmarks/benches/core_benchmarks.rs
@@ -1,12 +1,9 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use rush::greet;
+use std::hint::black_box;
 
 fn benchmark_function(c: &mut Criterion) {
-    c.bench_function("greet", |b| {
-        b.iter(|| {
-            black_box(greet())
-        })
-    });
+    c.bench_function("greet", |b| b.iter(|| black_box(greet())));
 }
 
 criterion_group!(benches, benchmark_function);


### PR DESCRIPTION
## Summary
- replace deprecated criterion black_box with std::hint::black_box in benchmark
- simplify benchmark closure
- update rustsec audit-check action to v2.0.0 so CI resolves correctly

## Testing
- `cargo test --all-features --workspace --quiet`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`


------
https://chatgpt.com/codex/tasks/task_e_6881b124e48c832ca6e8e5ade11f49ae